### PR TITLE
Replace Eventfd with EventSender/EventReceiver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ members = [
 virtio-bindings = "0.2.5"
 virtio-queue = "0.15.0"
 vm-memory = "0.16.2"
-vmm-sys-util = "0.14.0"
+vmm-sys-util = { git = "https://github.com/uran0sH/vmm-sys-util", branch = "event-abstract" }

--- a/vhost-user-backend/CHANGELOG.md
+++ b/vhost-user-backend/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 ### Changed
+- [[#308](https://github.com/rust-vmm/vhost/pull/308)] Replace Eventfd with EventNotifier/EventConsumer.
+
 ### Deprecated
 ### Fixed
 

--- a/vhost-user-backend/src/lib.rs
+++ b/vhost-user-backend/src/lib.rs
@@ -350,7 +350,7 @@ mod tests {
                 let fd = backend.exit_event(thread_id).unwrap();
                 // Reading from exit fd should fail since nothing was written yet
                 assert_eq!(
-                    fd.read().unwrap_err().raw_os_error().unwrap(),
+                    fd.0.consume().unwrap_err().raw_os_error().unwrap(),
                     EAGAIN,
                     "exit event should not have been raised yet!"
                 );
@@ -365,7 +365,7 @@ mod tests {
         let backend = backend.lock().unwrap();
         for thread_id in 0..backend.queues_per_thread().len() {
             let fd = backend.exit_event(thread_id).unwrap();
-            assert!(fd.read().is_ok(), "No exit event was raised!");
+            assert!(fd.0.consume().is_ok(), "No exit event was raised!");
         }
     }
 }


### PR DESCRIPTION
Eventfd is Linux-specific. To support more platforms, we replace it with
the EventNotifier/EventConsumer abstractions.
EventSender and EventReceiver are wrappers that encapsulate eventfd functionality